### PR TITLE
Use --extension mode of run_test.pl to simplify setup/run

### DIFF
--- a/src/test/sql/regress/topo_update.sql
+++ b/src/test/sql/regress/topo_update.sql
@@ -1,6 +1,6 @@
 SET pgtopo_update.session_id ='session_id';
 SET pgtopo_update.draw_line_opr = '1';
---SET client_min_messages to 'debug';
+SET client_min_messages to 'WARNING';
 
 -- TODO  add set pgtopo_update.session_replication_role
 


### PR DESCRIPTION
By using --extension we rely on postgis being available as an
extension so we don't have to mess with scripts and 00-regress